### PR TITLE
Adding -endpoint-url flag 

### DIFF
--- a/content/en/docs/01/resources/etcd-backup/cm_backup-script.yaml
+++ b/content/en/docs/01/resources/etcd-backup/cm_backup-script.yaml
@@ -10,4 +10,4 @@ data:
     set -u
 
     chroot /host /usr/local/bin/cluster-backup.sh /home/core/assets
-    aws s3 sync /host/home/core/assets/ "s3://${AWS_S3_BUCKET}/etcd-backup"
+    aws s3 sync /host/home/core/assets/ "s3://${AWS_S3_BUCKET}/etcd-backup" --endpoint-url ${AWS_ENDPOINT_URL}

--- a/content/en/docs/01/resources/etcd-backup/secret_etcd-backup-s3-bucket.yaml
+++ b/content/en/docs/01/resources/etcd-backup/secret_etcd-backup-s3-bucket.yaml
@@ -7,5 +7,4 @@ data:
   AWS_S3_BUCKET: 
   AWS_SECRET_ACCESS_KEY:
   AWS_ENDPOINT_URL: 
-  
 type: Opaque

--- a/content/en/docs/01/resources/etcd-backup/secret_etcd-backup-s3-bucket.yaml
+++ b/content/en/docs/01/resources/etcd-backup/secret_etcd-backup-s3-bucket.yaml
@@ -5,5 +5,7 @@ metadata:
 data:
   AWS_ACCESS_KEY_ID: 
   AWS_S3_BUCKET: 
-  AWS_SECRET_ACCESS_KEY: 
+  AWS_SECRET_ACCESS_KEY:
+  AWS_ENDPOINT_URL: 
+  
 type: Opaque


### PR DESCRIPTION
In order to connect to some other s3 compatible storage, it's needed to use `-endpoint-url ` flag. 