### PR TITLE
Removed scheduleName from Velero restore obj

### DIFF
--- a/content/en/docs/02/resources/restore_uptime-app-prod.yaml
+++ b/content/en/docs/02/resources/restore_uptime-app-prod.yaml
@@ -14,4 +14,3 @@ spec:
   hooks: {}
   includedNamespaces:
   - '*'
-  scheduleName: daily-backup-uptime-app-prod


### PR DESCRIPTION
When `backupName` and `scheduleName` is specified, a FailedValidation occurs: `Either a backup or schedule must be specified as a source for the restore, but not both`